### PR TITLE
Fix for pack-config-volume-mount includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed reference to st2-license pullSecrets, which was missed when removing enterprise flags (#192) (by @cognifloyd)
 * Add optional imagePullSecrets to ServiceAccount using `serviceAccount.pullSecret` from values.yaml. If pods do not have imagePullSecrets (eg without `image.pullSecret` in values.yaml), k8s populates them from the ServiceAccount. (#196) (by @cognifloyd)
 * Reformat some yaml strings so that single quotes wrap strings that include double quotes (#194) (by @cognifloyd)
+* New feature: Shared packs volumes `st2.packs.volumes` -- Instead of using `st2packs` images to install packs, allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. (#199) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,23 @@ Or, for example, to use NFS:
         path: /var/nfsshare/configs
 ```
 
+#### Caveat: Mounting and copying packs
+If you use something like NFS where you can mount the shares outside of the StackStorm pods, there are a couple of things to keep in mind.
+
+Though you could manually copy packs into the `packs` shared volume, be aware that StackStorm does not automatically register any changed content.
+So, if you manually copy a pack into the `packs` shared volume, then you also need to trigger updating the virtualenv and registering the content,
+possibly using APIs like:
+[packs/install](https://api.stackstorm.com/api/v1/packs/#/packs_controller.install.post), and
+[packs/register](https://api.stackstorm.com/api/v1/packs/#/packs_controller.register.post)
+You will have to repeat the process each time the packs code is modified.
+
+#### Caveat: System packs
+After Helm installs, upgrades, or rollsback a Stackstorm install, it runs an `st2-register-content` batch job.
+This job will copy and register system packs. If you have made any changes (like disabling default aliases), those changes will be overwritten.
+
+NOTE: Upgrades will not remove files (such as a renamed or removed action) if they were removed in newer StackStorm versions.
+This mirrors the how pack registration works. Make sure to review any upgrade notes and manually handle any removals.
+
 ## Tips & Tricks
 Grab all logs for entire StackStorm cluster with dependent services in Helm release:
 ```

--- a/README.md
+++ b/README.md
@@ -183,14 +183,15 @@ As any other Helm dependency, it's possible to further configure it for specific
 ## Install custom st2 packs in the cluster
 There are two ways to install st2 packs in the k8s cluster.
 
-1. The `st2packs` method is the default. This method will work for practiaclly all clusters, but `st2 pack install` does not work. The packs are injected via `st2packs` images instead.
+1. The `st2packs` method is the default. This method will work for practically all clusters, but `st2 pack install` does not work. The packs are injected via `st2packs` images instead.
 
 2. The other method defines shared/writable `volumes`. This method allows `st2 pack install` to work, but requires a persistent storage backend to be available in the cluster. This chart will not configure a storage backend for you.
 
 ### Method 1: st2packs images (the default)
 The `st2packs` method is the default. `st2 pack install` does not work because this chart uses read-only `emptyDir` volumes for `/opt/stackstorm/{packs,virtualenvs}`.
 Instead, you need to bake the packs into a custom docker image, push it to a private or public docker registry and reference that image in Helm values.
-Helm chart will take it from there, sharing `/opt/stackstorm/{packs,virtualenvs}` via a sidecar container in pods which require access to the packs (the sidcar is the only place where the volumes are writable).
+Helm chart will take it from there, sharing `/opt/stackstorm/{packs,virtualenvs}` via a sidecar container in pods which require access to the packs
+(the sidecar is the only place where the volumes are writable).
 
 #### Building st2packs image
 For your convenience, we created a new `st2-pack-install <pack1> <pack2> <pack3>` utility and included it in a container that will help to install custom packs during the Docker build process without relying on live DB and MQ connection.
@@ -296,7 +297,7 @@ possibly using APIs like:
 You will have to repeat the process each time the packs code is modified.
 
 #### Caveat: System packs
-After Helm installs, upgrades, or rollsback a Stackstorm install, it runs an `st2-register-content` batch job.
+After Helm installs, upgrades, or rolls back a StackStorm install, it runs an `st2-register-content` batch job.
 This job will copy and register system packs. If you have made any changes (like disabling default aliases), those changes will be overwritten.
 
 NOTE: Upgrades will not remove files (such as a renamed or removed action) if they were removed in newer StackStorm versions.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ st2:
       - name: circleci
         ref: circle_ci.CircleCIWebhookSensor
 ```
-	
+
 ### [st2actionrunner](https://docs.stackstorm.com/reference/ha.html#st2actionrunner)
 Stackstorm workers that actually execute actions.
 `5` replicas for K8s Deployment are configured by default to increase StackStorm ability to execute actions without excessive queuing.
@@ -181,15 +181,22 @@ StackStorm employs redis sentinel as a distributed coordination backend, require
 As any other Helm dependency, it's possible to further configure it for specific scaling needs via `values.yaml`.
 
 ## Install custom st2 packs in the cluster
-In distributed environment of the Kubernetes cluster `st2 pack install` won’t work.
-Instead, you need to bake the packs into a custom docker image, push it to a private or public docker registry and reference that image in Helm values.
-Helm chart will take it from there, sharing `/opt/stackstorm/{packs,virtualenvs}` via a sidecar container in pods which require access to the packs.
+There are two ways to install st2 packs in the k8s cluster.
 
-### Building st2packs image
+1. The `st2packs` method is the default. This method will work for practiaclly all clusters, but `st2 pack install` does not work. The packs are injected via `st2packs` images instead.
+
+2. The other method defines shared/writable `volumes`. This method allows `st2 pack install` to work, but requires a persistent storage backend to be available in the cluster. This chart will not configure a storage backend for you.
+
+### Method 1: st2packs images (the default)
+The `st2packs` method is the default. `st2 pack install` does not work because this chart uses read-only `emptyDir` volumes for `/opt/stackstorm/{packs,virtualenvs}`.
+Instead, you need to bake the packs into a custom docker image, push it to a private or public docker registry and reference that image in Helm values.
+Helm chart will take it from there, sharing `/opt/stackstorm/{packs,virtualenvs}` via a sidecar container in pods which require access to the packs (the sidcar is the only place where the volumes are writable).
+
+#### Building st2packs image
 For your convenience, we created a new `st2-pack-install <pack1> <pack2> <pack3>` utility and included it in a container that will help to install custom packs during the Docker build process without relying on live DB and MQ connection.
 Please see https://github.com/StackStorm/st2packs-dockerfiles/ for instructions on how to build your custom `st2packs` image.
 
-### How to provide custom pack configs
+#### How to provide custom pack configs
 Update the `st2.packs.configs` section of Helm values:
 
 For example:
@@ -205,7 +212,7 @@ For example:
 ```
 Don't forget running Helm upgrade to apply new changes.
 
-### Pull st2packs from a private Docker registry
+#### Pull st2packs from a private Docker registry
 If you need to pull your custom packs Docker image from a private repository, create a Kubernetes Docker registry secret and pass it to Helm values.
 See [K8s documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more info.
 ```
@@ -214,6 +221,69 @@ kubectl create secret docker-registry st2packs-auth --docker-server=<your-regist
 ```
 Once secret created, reference its name in helm value: `st2.packs.images[].pullSecret`.
 
+### Method 2: Shared Volumes
+This method requires cluster-specific storage setup and configuration. As the storage volumes are both writable and shared, `st2 pack install` should work like it does for standalone StackStorm installations. The volumes get mounted at `/opt/stackstorm/{packs,virtualenvs}` in the containers that need read or write access to those directories. With this method, `/opt/stackstorm/configs` can also be mounted as a writable volume instead of using `st2.packs.configs`.
+
+#### Configure the storage volumes
+Enable the `st2.packs.voluems` section of Helm values and add volume definitions for both `packs` and `virtualenvs`.
+Each of the volume definitions should be customized for your cluster and storage solution.
+
+NOTE: Make sure that `st2.packs.images` is empty. This method does not use or work with the `st2packs` images.
+
+For example, to use persistentVolumeClaims:
+```
+  volumes:
+    enabled: true
+    packs:
+      persistentVolumeClaim:
+        claim-name: pvc-st2-packs
+    virtualenvs:
+      persistentVolumeClaim:
+        claim-name: pvc-st2-virtualenvs
+```
+
+Or, for example, to use NFS:
+```
+  volumes:
+    enabled: true
+    packs:
+      nfs:
+        server: nfs.example.com
+        path: /var/nfsshare/packs
+    virtualenvs:
+      nfs:
+        server: nfs.example.com
+        path: /var/nfsshare/virtualenvs
+```
+
+Please consult the documentation for your cluster's storage solution to see how to add the storage backend to your cluster and how to define volumes that use your storage backend.
+
+#### How to provide custom pack configs
+You may either use the `st2.packs.configs` section of Helm values (like Method 1, see above),
+or add another shared writable volume similar to `packs` and `virtualenvs`. This volume gets mounted
+to `/opt/stackstorm/configs` instead of the `st2.packs.config` values. NOTE: If you define a configs volume,
+anything in `st2.packs.configs` will NOT be visible to StackStorm.
+
+For example, to use persistentVolumeClaims:
+```
+  volumes:
+    enabled: true
+    ... # define packs and virtualenvs volumes as shown above
+    configs:
+      persistentVolumeClaim:
+        claim-name: pvc-st2-pack-configs
+```
+
+Or, for example, to use NFS:
+```
+  volumes:
+    enabled: true
+    ... # define packs and virtualenvs volumes as shown above
+    configs:
+      nfs:
+        server: nfs.example.com
+        path: /var/nfsshare/configs
+```
 
 ## Tips & Tricks
 Grab all logs for entire StackStorm cluster with dependent services in Helm release:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -114,6 +114,25 @@ Create the name of the stackstorm-ha service account to use
   emptyDir: {}
   {{- end }}
 {{- end -}}
+{{- define "packs-volume-mounts" -}}
+  {{- if .Values.st2.packs.images }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+  readOnly: true
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
+  readOnly: true
+  {{- end }}
+{{- end -}}
+# define this here as well to simplify comparison with packs-volume-mounts
+{{- define "packs-volume-mounts-for-register-job" -}}
+  {{- if .Values.st2.packs.images }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
+  {{- end }}
+{{- end -}}
 
 # For custom st2packs-initContainers reduce duplicity by defining them here once
 # Merge packs and virtualenvs from st2 with those from st2packs images

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -180,6 +180,8 @@ Create the name of the stackstorm-ha service account to use
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
     {{- end }}
+  {{- end }}
+  {{- if or $.Values.st2.packs.images $.Values.st2.packs.volumes.enabled }}
 # System packs
 - name: st2-system-packs
   image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -105,6 +105,17 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
+# consolidate pack-configs-volumes definitions
+{{- define "pack-configs-volume" -}}
+- name: st2-pack-configs-vol
+  configMap:
+    name: {{ .Release.Name }}-st2-pack-configs
+{{- end -}}
+{{- define "pack-configs-volume-mount" -}}
+- name: st2-pack-configs-vol
+  mountPath: /opt/stackstorm/configs/
+{{- end -}}
+
 # For custom st2packs-Container reduce duplicity by defining it here once
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.images }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -107,9 +107,14 @@ Create the name of the stackstorm-ha service account to use
 
 # consolidate pack-configs-volumes definitions
 {{- define "pack-configs-volume" -}}
+  {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs }}
+- name: st2-pack-configs-vol
+{{ toYaml .Values.st2.packs.volumes.configs | indent 2 }}
+  {{- else }}
 - name: st2-pack-configs-vol
   configMap:
     name: {{ .Release.Name }}-st2-pack-configs
+  {{- end }}
 {{- end -}}
 {{- define "pack-configs-volume-mount" -}}
 - name: st2-pack-configs-vol

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -112,6 +112,11 @@ Create the name of the stackstorm-ha service account to use
   emptyDir: {}
 - name: st2-virtualenvs-vol
   emptyDir: {}
+  {{- else if .Values.st2.packs.volumes.enabled }}
+- name: st2-packs-vol
+{{ toYaml .Values.st2.packs.volumes.packs | indent 2 }}
+- name: st2-virtualenvs-vol
+{{ toYaml .Values.st2.packs.volumes.virtualenvs | indent 2 }}
   {{- end }}
 {{- end -}}
 {{- define "packs-volume-mounts" -}}
@@ -122,11 +127,16 @@ Create the name of the stackstorm-ha service account to use
 - name: st2-virtualenvs-vol
   mountPath: /opt/stackstorm/virtualenvs
   readOnly: true
+  {{- else if .Values.st2.packs.volumes.enabled }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
   {{- end }}
 {{- end -}}
 # define this here as well to simplify comparison with packs-volume-mounts
 {{- define "packs-volume-mounts-for-register-job" -}}
-  {{- if .Values.st2.packs.images }}
+  {{- if or .Values.st2.packs.images .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
   mountPath: /opt/stackstorm/packs
 - name: st2-virtualenvs-vol

--- a/templates/configmaps_packs.yaml
+++ b/templates/configmaps_packs.yaml
@@ -1,3 +1,4 @@
+{{- if not (and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,3 +15,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{ toYaml .Values.st2.packs.configs | indent 2 }}
+{{- end -}}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -2,6 +2,14 @@
 {{- if and .Values.st2.packs.image }}
 {{- fail "Value st2.packs.image was renamed to st2.packs.images and is now a list of images" }}
 {{- end }}
+{{- if .Values.st2.packs.volumes.enabled }}
+  {{- if .Values.st2.packs.images }}
+{{- fail "st2.packs.images is not compatible with st2.packs.volumes.enabled. Please use only one method for setting up packs directories." }}
+  {{- end }}
+  {{- if not (and .Values.st2.packs.volumes.packs .Values.st2.packs.volumes.virtualenvs) }}
+{{- fail "Volume definition(s) missing! When st2.packs.volumes.enabled, you must define volumes for both packs and virtualenvs." }}
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: apps/v1

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -192,7 +192,7 @@ spec:
           readOnly: true
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
-        {{- if and .Values.st2.packs.volumes.enabled }}
+        {{- if .Values.st2.packs.volumes.enabled }}
 {{- include "pack-configs-volume-mount" . | indent 8}}
         {{- end }}
         resources:
@@ -213,7 +213,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-config
 {{ include "packs-volumes" . | indent 8 }}
-        {{- if and .Values.st2.packs.volumes.enabled }}
+        {{- if .Values.st2.packs.volumes.enabled }}
 {{- include "pack-configs-volume" . | indent 8}}
         {{- end }}
     {{- with .Values.st2api.nodeSelector }}
@@ -1035,7 +1035,7 @@ spec:
           readOnly: true
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
-        {{- if and .Values.st2.packs.volumes.enabled }}
+        {{- if .Values.st2.packs.volumes.enabled }}
 {{- include "pack-configs-volume-mount" . | indent 8}}
         {{- end }}
         resources:
@@ -1064,7 +1064,7 @@ spec:
               # 0400 file permission
               mode: 256
 {{ include "packs-volumes" . | indent 8 }}
-        {{- if and .Values.st2.packs.volumes.enabled }}
+        {{- if .Values.st2.packs.volumes.enabled }}
 {{- include "pack-configs-volume" . | indent 8}}
         {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1240,8 +1240,6 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }} 
-        - name: st2-pack-configs-vol
-          mountPath: /opt/stackstorm/configs/
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
@@ -1253,6 +1251,7 @@ spec:
           readOnly: true
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
+{{ include "pack-configs-volume-mount" . | indent 8}}
         command:
           - 'bash'
           - '-ec'
@@ -1284,9 +1283,6 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        - name: st2-pack-configs-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-pack-configs
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
@@ -1299,6 +1295,7 @@ spec:
               # 0400 file permission
               mode: 256
 {{ include "packs-volumes" . | indent 8 }}
+{{ include "pack-configs-volume" . | indent 8}}
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -183,14 +183,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+{{ include "packs-volume-mounts" . | indent 8 }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
     {{- if .Values.st2api.serviceAccount.attach }}
@@ -208,9 +201,7 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+{{ include "packs-volumes" . | indent 8 }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -911,14 +902,7 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if $.Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+{{ include "packs-volume-mounts" $ | indent 8 }}
         {{- if $.Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -941,9 +925,7 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ $.Release.Name }}-st2-config
-        {{- if $.Values.st2.packs.images }}
-{{- include "packs-volumes" $ | indent 8 }}
-        {{- end }}
+{{ include "packs-volumes" $ | indent 8 }}
     {{- with .nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -1038,14 +1020,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+{{ include "packs-volume-mounts" . | indent 8 }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
     {{- if .Values.st2actionrunner.serviceAccount.attach }}
@@ -1071,9 +1046,7 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+{{ include "packs-volumes" . | indent 8 }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -1279,14 +1252,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+{{ include "packs-volume-mounts" . | indent 8 }}
         command:
           - 'bash'
           - '-ec'
@@ -1332,9 +1298,7 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+{{ include "packs-volumes" . | indent 8 }}
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -184,6 +184,9 @@ spec:
           readOnly: true
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
+        {{- if and .Values.st2.packs.volumes.enabled }}
+{{- include "pack-configs-volume-mount" . | indent 8}}
+        {{- end }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
     {{- if .Values.st2api.serviceAccount.attach }}
@@ -202,6 +205,9 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-config
 {{ include "packs-volumes" . | indent 8 }}
+        {{- if and .Values.st2.packs.volumes.enabled }}
+{{- include "pack-configs-volume" . | indent 8}}
+        {{- end }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -1021,6 +1027,9 @@ spec:
           readOnly: true
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
+        {{- if and .Values.st2.packs.volumes.enabled }}
+{{- include "pack-configs-volume-mount" . | indent 8}}
+        {{- end }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
     {{- if .Values.st2actionrunner.serviceAccount.attach }}
@@ -1047,6 +1056,9 @@ spec:
               # 0400 file permission
               mode: 256
 {{ include "packs-volumes" . | indent 8 }}
+        {{- if and .Values.st2.packs.volumes.enabled }}
+{{- include "pack-configs-volume" . | indent 8}}
+        {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -193,7 +193,7 @@ spec:
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-{{- include "pack-configs-volume-mount" . | indent 8}}
+{{ include "pack-configs-volume-mount" . | indent 8}}
         {{- end }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
@@ -1036,7 +1036,7 @@ spec:
         {{- end }}
 {{ include "packs-volume-mounts" . | indent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-{{- include "pack-configs-volume-mount" . | indent 8}}
+{{ include "pack-configs-volume-mount" . | indent 8}}
         {{- end }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -352,17 +352,14 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        - name: st2-pack-configs-vol
-          mountPath: /opt/stackstorm/configs/
 {{ include "packs-volume-mounts-for-register-job" . | indent 8 }}
+{{ include "pack-configs-volume-mount" . | indent 8}}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        - name: st2-pack-configs-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-pack-configs
-{{ include "packs-volumes" $ | indent 8}}
+{{ include "packs-volumes" . | indent 8}}
+{{ include "pack-configs-volume" . | indent 8}}
       restartPolicy: OnFailure

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -354,12 +354,7 @@ spec:
           subPath: st2.user.conf
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs/
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs/
-        {{- end }}
+{{ include "packs-volume-mounts-for-register-job" . | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -369,5 +364,5 @@ spec:
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs
- {{- include "packs-volumes" $ | indent 8}}
+{{ include "packs-volumes" $ | indent 8}}
       restartPolicy: OnFailure

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -331,9 +331,7 @@ spec:
       {{- end }}
       initContainers:
       {{ include "init-containers-wait-for-db" . | indent 6 }}
-      {{- if $.Values.st2.packs.images -}}
- {{- include "packs-initContainers" . | indent 6 }}
-      {{ end }}
+      {{ include "packs-initContainers" . | indent 6 }}
       containers:
       - name: st2-register-content
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'

--- a/values.yaml
+++ b/values.yaml
@@ -45,9 +45,11 @@ st2:
 
   # Custom pack configs and image settings.
   #
-  # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
-  # you will need to bake additional packs into an 'st2packs' image. Please see github.com/stackstorm/stackstorm-ha/README.md
+  # By default, system packs are available. By default, however, `st2 pack install` cannot be run in the k8s cluster,
+  # so you will need to bake additional packs into an 'st2packs' image. Please see github.com/stackstorm/stackstorm-ha/README.md
   # for details on how to build this image.
+  # To change this default, and use persistent/shared/writable storage that is available in your cluster, you need to
+  # enable st2.packs.volumes below, adding volume definitions customized for use your cluster's storage provider.
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
@@ -57,9 +59,12 @@ st2:
         # example core pack config yaml
 
     # Custom packs images settings.
+    #
     # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
     # Multiple pack images can help when dealing with frequent updates by only rebuilding smaller images for desired packs
     # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
+    #
+    # This must be empty if st2.packs.volumes is enabled.
     images:
       #- repository: index.docker.io/stackstorm
       #  name: st2packs
@@ -67,6 +72,47 @@ st2:
       #  pullPolicy: IfNotPresent
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry
       #  pullSecret: st2packs-auth
+
+    # Custom packs volumes definitions.
+    #
+    # Use this instead of st2.packs.images to have StackStorm use persistent/shared/writable storage configured
+    # previously in your cluster. The choice of storage solution is cluster-dependent (it changes besed on where the
+    # cluster is hosted and which storage solutions are available in your cluster).
+    #
+    # To use this, set enabled to true, and add cluster-specific volume definitions for at least packs and virtualenvs below.
+    # Please consult the documentation for your cluster's storage solution.
+    # Some generic examples are listed under st2.packs.volumes.packs below.
+    volumes:
+      # to enable st2.packs.volumes, st2.packs.images must not be empty
+      enabled: false
+
+      packs: # mounted to /opt/stackstorm/packs
+        # packs volume definition is required if st2.packs.volumes is enabled
+
+        # example using persistentVolumeClaim:
+        #persistentVolumeClaim:
+        #  claim-name: pvc-st2-packs
+
+        # example using NFS:
+        #nfs:
+        #  server: "10.12.34.56"
+        #  path: /var/nfsshare/packs
+
+        # example using a flexVolume + rook-ceph
+        #flexVolume:
+        #  driver: ceph.rook.io/rook
+        #  options:
+        #    fsName: fs1
+        #    clusterNamespace: rook-ceph
+        #    path: /st2/packs
+
+      virtualenvs: # mounted to /opt/stackstorm/virtualenvs
+        # virtualenvs volume definition is required if st2.packs.volumes is enabled
+        # see the examples under st2.packs.volumes.packs
+
+      configs: # mounted to /opt/stackstorm/configs
+        # configs volume definition is optional, but only used if st2.packs.volumes is enabled
+        # see the examples under st2.packs.volumes.packs
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,7 @@ st2:
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
+    # NOTE: This is ignored if st2.packs.volumes.configs is defined and st2.packs.volumes is enabled
     configs:
       core.yaml: |
         ---


### PR DESCRIPTION
Without this fix, Helm3 was spitting out invalid YAML that looked like this:

```
        - name: st2-packs-vol
          mountPath: /opt/stackstorm/packs
        - name: st2-virtualenvs-vol
          mountPath: /opt/stackstorm/virtualenvs        - name: st2-pack-configs-vol
          mountPath: /opt/stackstorm/configs/

```